### PR TITLE
fix: remove resourceVersion before SSAPatch

### DIFF
--- a/controllers/sleepinfo/cronjobs/cronjobs.go
+++ b/controllers/sleepinfo/cronjobs/cronjobs.go
@@ -63,6 +63,7 @@ func (c cronjobs) Sleep(ctx context.Context) error {
 			continue
 		}
 		newCronJob := cronjob.DeepCopy()
+		unstructured.RemoveNestedField(newCronJob.Object, "metadata", "resourceVersion")
 		if err = unstructured.SetNestedField(newCronJob.Object, true, "spec", "suspend"); err != nil {
 			return err
 		}


### PR DESCRIPTION
Remove `resourceVersion` field before calling Server Side Apply patch ([link](https://kubernetes.io/docs/reference/using-api/server-side-apply/#using-server-side-apply-in-a-controller)).

This PR resolves https://github.com/kube-green/kube-green/issues/206