### PR TITLE
Add support to edit sleep delta

### DIFF
--- a/controllers/sleepinfo/schedule.go
+++ b/controllers/sleepinfo/schedule.go
@@ -7,8 +7,8 @@ import (
 	"github.com/robfig/cron/v3"
 )
 
-func (r *SleepInfoReconciler) getNextSchedule(data SleepInfoData, now time.Time, scheduleDeltaSeconds int64) (bool, time.Time, time.Duration, error) {
-	scheduleDelta := time.Duration(scheduleDeltaSeconds) * time.Second
+func (r *SleepInfoReconciler) getNextSchedule(data SleepInfoData, now time.Time) (bool, time.Time, time.Duration, error) {
+	scheduleDelta := time.Duration(r.SleepDelta) * time.Second
 	sched, err := getCronParsed(data.CurrentOperationSchedule)
 	if err != nil {
 		return false, time.Time{}, 0, fmt.Errorf("current schedule not valid: %s", err)

--- a/controllers/sleepinfo/schedule_test.go
+++ b/controllers/sleepinfo/schedule_test.go
@@ -13,7 +13,8 @@ func TestSchedule(t *testing.T) {
 	testLogger := zap.New(zap.UseDevMode(true))
 
 	sleepInfoReconciler := SleepInfoReconciler{
-		Log: testLogger,
+		Log:        testLogger,
+		SleepDelta: 60,
 	}
 
 	type expected struct {
@@ -387,7 +388,7 @@ func TestSchedule(t *testing.T) {
 			if scheduleDeltaSeconds == 0 {
 				scheduleDeltaSeconds = 1
 			}
-			isToExecute, nextSchedule, requeueAfter, err := sleepInfoReconciler.getNextSchedule(test.data, getTime(t, test.now), scheduleDeltaSeconds)
+			isToExecute, nextSchedule, requeueAfter, err := sleepInfoReconciler.getNextSchedule(test.data, getTime(t, test.now))
 
 			expected := test.expected
 			if expected.err != "" {

--- a/controllers/sleepinfo/secrets_test.go
+++ b/controllers/sleepinfo/secrets_test.go
@@ -39,8 +39,9 @@ func TestGetSecret(t *testing.T) {
 				Build(),
 		}
 		r := SleepInfoReconciler{
-			Client: client,
-			Log:    testLogger,
+			Client:     client,
+			Log:        testLogger,
+			SleepDelta: 60,
 		}
 
 		secret, err := r.getSecret(context.Background(), secretName, namespace)
@@ -68,8 +69,9 @@ func TestGetSecret(t *testing.T) {
 				Build(),
 		}
 		r := SleepInfoReconciler{
-			Client: client,
-			Log:    testLogger,
+			Client:     client,
+			Log:        testLogger,
+			SleepDelta: 60,
 		}
 
 		secret, err := r.getSecret(context.Background(), secretName, namespace)
@@ -127,8 +129,9 @@ func TestUpsertSecrets(t *testing.T) {
 		}
 
 		r := SleepInfoReconciler{
-			Client: client,
-			Log:    testLogger,
+			Client:     client,
+			Log:        testLogger,
+			SleepDelta: 60,
 		}
 		sleepInfoData := SleepInfoData{
 			CurrentOperationType: sleepOperation,
@@ -202,8 +205,9 @@ func TestUpsertSecrets(t *testing.T) {
 		}
 
 		r := SleepInfoReconciler{
-			Client: client,
-			Log:    testLogger,
+			Client:     client,
+			Log:        testLogger,
+			SleepDelta: 60,
 		}
 		sleepInfoData := SleepInfoData{
 			CurrentOperationType: sleepOperation,
@@ -298,8 +302,9 @@ func TestUpsertSecrets(t *testing.T) {
 				Build(),
 		}
 		r := SleepInfoReconciler{
-			Client: client,
-			Log:    testLogger,
+			Client:     client,
+			Log:        testLogger,
+			SleepDelta: 60,
 		}
 		sleepInfoData := SleepInfoData{
 			CurrentOperationType: sleepOperation,
@@ -351,8 +356,9 @@ func TestUpsertSecrets(t *testing.T) {
 		}
 
 		r := SleepInfoReconciler{
-			Client: client,
-			Log:    testLogger,
+			Client:     client,
+			Log:        testLogger,
+			SleepDelta: 60,
 		}
 		sleepInfoData := SleepInfoData{
 			CurrentOperationType: sleepOperation,
@@ -396,8 +402,9 @@ func TestUpsertSecrets(t *testing.T) {
 			},
 		}
 		r := SleepInfoReconciler{
-			Client: client,
-			Log:    testLogger,
+			Client:     client,
+			Log:        testLogger,
+			SleepDelta: 60,
 		}
 		sleepInfoData := SleepInfoData{
 			CurrentOperationType: sleepOperation,
@@ -436,8 +443,9 @@ func TestUpsertSecrets(t *testing.T) {
 			},
 		}
 		r := SleepInfoReconciler{
-			Client: client,
-			Log:    testLogger,
+			Client:     client,
+			Log:        testLogger,
+			SleepDelta: 60,
 		}
 		sleepInfoData := SleepInfoData{
 			CurrentOperationType: sleepOperation,

--- a/controllers/sleepinfo/sleepinfo_controller.go
+++ b/controllers/sleepinfo/sleepinfo_controller.go
@@ -44,7 +44,8 @@ type SleepInfoReconciler struct {
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 	Clock
-	Metrics metrics.Metrics
+	Metrics    metrics.Metrics
+	SleepDelta int64
 }
 
 type realClock struct{}
@@ -58,8 +59,6 @@ func (realClock) Now() time.Time {
 type Clock interface {
 	Now() time.Time
 }
-
-var sleepDelta int64 = 60
 
 //+kubebuilder:rbac:groups=kube-green.com,resources=sleepinfos,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=kube-green.com,resources=sleepinfos/status,verbs=get;update;patch
@@ -108,7 +107,7 @@ func (r *SleepInfoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 	now := r.Clock.Now()
 
-	isToExecute, nextSchedule, requeueAfter, err := r.getNextSchedule(sleepInfoData, now, sleepDelta)
+	isToExecute, nextSchedule, requeueAfter, err := r.getNextSchedule(sleepInfoData, now)
 	if err != nil {
 		log.Error(err, "unable to update deployment with 0 replicas")
 		return ctrl.Result{}, err

--- a/controllers/sleepinfo/sleepinfo_test.go
+++ b/controllers/sleepinfo/sleepinfo_test.go
@@ -826,9 +826,10 @@ func getSleepInfoReconciler(t *testing.T, c *envconf.Config, logger logr.Logger,
 			now: now,
 			t:   t,
 		},
-		Client:  k8sClient,
-		Log:     logger,
-		Metrics: metrics.SetupMetricsOrDie("kube_green"),
+		Client:     k8sClient,
+		Log:        logger,
+		Metrics:    metrics.SetupMetricsOrDie("kube_green"),
+		SleepDelta: 60,
 	}
 }
 
@@ -840,9 +841,10 @@ func assertCorrectSleepOperation2(t *testing.T, ctx context.Context, cfg *envcon
 			now: assert.scheduleTime,
 			t:   t,
 		},
-		Client:  assert.reconciler.Client,
-		Log:     assert.reconciler.Log,
-		Metrics: assert.reconciler.Metrics,
+		Client:     assert.reconciler.Client,
+		Log:        assert.reconciler.Log,
+		Metrics:    assert.reconciler.Metrics,
+		SleepDelta: 60,
 	}
 	result, err := sleepInfoReconciler.Reconcile(ctx, assert.req)
 	require.NoError(t, err)
@@ -1006,9 +1008,10 @@ func assertCorrectWakeUpOperation2(t *testing.T, ctx context.Context, cfg *envco
 			now: assert.scheduleTime,
 			t:   t,
 		},
-		Client:  assert.reconciler.Client,
-		Log:     assert.reconciler.Log,
-		Metrics: assert.reconciler.Metrics,
+		Client:     assert.reconciler.Client,
+		Log:        assert.reconciler.Log,
+		Metrics:    assert.reconciler.Metrics,
+		SleepDelta: 60,
 	}
 
 	result, err := sleepInfoReconciler.Reconcile(ctx, assert.req)

--- a/main.go
+++ b/main.go
@@ -43,9 +43,11 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var sleepDelta int64
 	flag.IntVar(&webhookPort, "webhook-server-port", 9443, "The port where the server will listen.")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.Int64Var(&sleepDelta, "sleep-delta", 60, "The delta in seconds between the cronjob schedule and when the job is being processed before skipping it")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -73,10 +75,11 @@ func main() {
 	customMetrics := metrics.SetupMetricsOrDie("kube_green").MustRegister(ctrlMetrics.Registry)
 
 	if err = (&sleepinfocontroller.SleepInfoReconciler{
-		Client:  mgr.GetClient(),
-		Log:     ctrl.Log.WithName("controllers").WithName("SleepInfo"),
-		Scheme:  mgr.GetScheme(),
-		Metrics: customMetrics,
+		Client:     mgr.GetClient(),
+		Log:        ctrl.Log.WithName("controllers").WithName("SleepInfo"),
+		Scheme:     mgr.GetScheme(),
+		Metrics:    customMetrics,
+		SleepDelta: sleepDelta,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SleepInfo")
 		os.Exit(1)


### PR DESCRIPTION
# Description

Make the sleep delta parameter editable to allow an increased delay between the cronjob schedule and when the job is being processed. On large clusters, the reconciliation loop can be saturated (> 10), which might cause a job to be processed 1-2 minutes after it's scheduled time. By adding this option, we allow longer job processing times on large clusters and ensure all jobs can be processed (not skipped).

Should fix https://github.com/kube-green/kube-green/issues/246