### PR TITLE
Update kube-green.clusterserviceversion.yaml

### DIFF
--- a/bundle/manifests/kube-green.clusterserviceversion.yaml
+++ b/bundle/manifests/kube-green.clusterserviceversion.yaml
@@ -225,7 +225,7 @@ spec:
               containers:
               - args:
                 - --health-probe-bind-address=:8081
-                - --metrics-bind-address=127.0.0.1:8080
+                - --metrics-bind-address=0.0.0.0:8080
                 - --leader-elect
                 command:
                 - /manager
@@ -261,7 +261,7 @@ spec:
                     - ALL
               - args:
                 - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
+                - --upstream=http://0.0.0.0:8080/
                 - --logtostderr=true
                 - --v=0
                 image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0


### PR DESCRIPTION
To expose metrics to prometheus, changed endpoint to 0.0.0.0.

Hello,

With 127.0.0.1, we are unable to expose metrics, it only works with port-forwarding on localhost. So, changed to 0.0.0.0, to make it work with openshift routes and service monitor.