### PR TITLE
feat: modify clusterrole for sts support

### DIFF
--- a/charts/kube-green/templates/cluster_role.yaml
+++ b/charts/kube-green/templates/cluster_role.yaml
@@ -9,6 +9,7 @@ rules:
   - apps
   resources:
   - deployments
+  - statefulsets
   verbs:
   - create
   - delete


### PR DESCRIPTION
@davidebianchi my latest PR added support for StatefulSets, but the helm chart is missing required permissions for that. This PR fixes that issue.