### PR TITLE
helm chart: use imagePullSecrets in deployment template

### DIFF
--- a/charts/kube-green/templates/deployment.yaml
+++ b/charts/kube-green/templates/deployment.yaml
@@ -98,6 +98,10 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 10
       volumes:
       - name: cert


### PR DESCRIPTION
First of: Thanks a lot for your effort and great work here.

In the current `deployment.yaml` in the helm chart, the `imagePullSecrets` from the values was never referenced.
This PR fixes the bug that images could not be pulled from private registries.

Tested successfully in our v1.27 cluster with private registry.
