### PR TITLE
fix: remove .EXPORT_ALL_VARIABLES in Makefile, only export needed env.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,11 @@ ARCH              =$(shell go env GOARCH)
 GIT_SHA           =$(shell git rev-parse HEAD)
 BUILD_PATH        := cmd/main.go
 
-.EXPORT_ALL_VARIABLES:
+# Export only the variables needed by external tools like goreleaser
+export BUILD_PATH
+export GIT_SHA
+export OS
+export ARCH
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")

--- a/scripts/make/helm.mk
+++ b/scripts/make/helm.mk
@@ -2,7 +2,6 @@ HELM_TMPL_CMD ?= helm template -f charts/kube-green/values.yaml -f charts/kube-g
 HELM_TMPL_OUT ?= .helm.template-output.yaml
 HELM_SNAPSHOT_OUT ?= charts/snapshots/test-output.snap.yaml
 tmpl_debug ?=
-SHELL=/usr/bin/env bash
 
 ##@ Helm Chart utilities
 .PHONY: chart-snapshot


### PR DESCRIPTION
- also remove SHELL in hel.mk as it has been set in Makefile


issue:
.EXPORT_ALL_VARIABLES in an env with has too many env variable is causing problem.
which hangs even on the  simple calls  like "make help"
