### PR TITLE
update: clarify timezone in docs + add release on newer OCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ See [here](https://kube-green.dev/docs/configuration/) the documentation about t
 
 ### CRD Examples
 
+**Note:** The `timeZone` field uses IANA time zone identifiers. If not set, it defaults to UTC. You can set it to any valid timezone such as `Europe/Rome`, `America/New_York`, etc.
+
 Pods running during working hours with Europe/Rome timezone, suspend CronJobs and exclude a deployment named `api-gateway`:
 
 ```yaml

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -13,5 +13,5 @@ annotations:
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
   # OpenShift annotations.
-  com.redhat.openshift.versions: 4.14-4.17
+  com.redhat.openshift.versions: 4.15-4.20
 


### PR DESCRIPTION
- OCP 4.14 is EOL, current 4.19 does not received operator from OperatorHub


issue:
- could not instsall on new OCP cluster
- since the alm-example is using Rome as timezone it is good to point default is using UTC