### PR TITLE
update: various build + security change

### DIFF
--- a/bundle/manifests/kube-green.clusterserviceversion.yaml
+++ b/bundle/manifests/kube-green.clusterserviceversion.yaml
@@ -32,7 +32,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Developer Tools
     containerImage: docker.io/kubegreen/kube-green:0.7.1
-    createdAt: "2025-10-24T20:14:48Z"
+    createdAt: "2025-10-31T10:52:05Z"
     description: Suspend your pods when no-one's using them to save energy and restore
       when necessary
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
@@ -301,6 +301,8 @@ spec:
                     - ALL
               securityContext:
                 runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               serviceAccountName: kube-green-controller-manager
               terminationGracePeriodSeconds: 10
       permissions:

--- a/charts/kube-green/templates/cert-manager.yaml
+++ b/charts/kube-green/templates/cert-manager.yaml
@@ -12,6 +12,13 @@ spec:
     kind: Issuer
     name: kube-green-selfsigned-issuer
   secretName: {{ include "kube-green.webhook.secret.name" . }}
+  # Explicitly set privateKey.rotationPolicy to Never to maintain backward compatibility
+  # with cert-manager <1.18. In 1.18+, the default changed from Never to Always.
+  privateKey:
+    rotationPolicy: Never
+  # Explicitly set revisionHistoryLimit to preserve previous behavior.
+  # In cert-manager 1.18+, the default changed from unlimited to 1.
+  revisionHistoryLimit: 1
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
@@ -35,5 +42,12 @@ spec:
     kind: Issuer
     name: kube-green-selfsigned-issuer
   secretName: {{ include "kube-green.metrics.secret.name" . }}
+  # Explicitly set privateKey.rotationPolicy to Never to maintain backward compatibility
+  # with cert-manager <1.18. In 1.18+, the default changed from Never to Always.
+  privateKey:
+    rotationPolicy: Never
+  # Explicitly set revisionHistoryLimit to preserve previous behavior.
+  # In cert-manager 1.18+, the default changed from unlimited to 1.
+  revisionHistoryLimit: 1
 {{- end -}}
 {{ end -}}

--- a/charts/snapshots/test-output.snap.yaml
+++ b/charts/snapshots/test-output.snap.yaml
@@ -573,6 +573,13 @@ spec:
     kind: Issuer
     name: kube-green-selfsigned-issuer
   secretName: webhook-server-cert
+  # Explicitly set privateKey.rotationPolicy to Never to maintain backward compatibility
+  # with cert-manager <1.18. In 1.18+, the default changed from Never to Always.
+  privateKey:
+    rotationPolicy: Never
+  # Explicitly set revisionHistoryLimit to preserve previous behavior.
+  # In cert-manager 1.18+, the default changed from unlimited to 1.
+  revisionHistoryLimit: 1
 ---
 # Source: kube-green/templates/cert-manager.yaml
 apiVersion: cert-manager.io/v1
@@ -588,6 +595,13 @@ spec:
     kind: Issuer
     name: kube-green-selfsigned-issuer
   secretName: metrics-server-cert
+  # Explicitly set privateKey.rotationPolicy to Never to maintain backward compatibility
+  # with cert-manager <1.18. In 1.18+, the default changed from Never to Always.
+  privateKey:
+    rotationPolicy: Never
+  # Explicitly set revisionHistoryLimit to preserve previous behavior.
+  # In cert-manager 1.18+, the default changed from unlimited to 1.
+  revisionHistoryLimit: 1
 ---
 # Source: kube-green/templates/cert-manager.yaml
 apiVersion: cert-manager.io/v1

--- a/config/certmanager/certificate-metrics.yaml
+++ b/config/certmanager/certificate-metrics.yaml
@@ -18,3 +18,10 @@ spec:
     kind: Issuer
     name: selfsigned-issuer
   secretName: metrics-server-cert
+  # Explicitly set privateKey.rotationPolicy to Never to maintain backward compatibility
+  # with cert-manager <1.18. In 1.18+, the default changed from Never to Always.
+  privateKey:
+    rotationPolicy: Never
+  # Explicitly set revisionHistoryLimit to preserve previous behavior.
+  # In cert-manager 1.18+, the default changed from unlimited to 1.
+  revisionHistoryLimit: 1

--- a/config/certmanager/certificate-webhook.yaml
+++ b/config/certmanager/certificate-webhook.yaml
@@ -18,3 +18,10 @@ spec:
     kind: Issuer
     name: selfsigned-issuer
   secretName: webhook-server-cert
+  # Explicitly set privateKey.rotationPolicy to Never to maintain backward compatibility
+  # with cert-manager <1.18. In 1.18+, the default changed from Never to Always.
+  privateKey:
+    rotationPolicy: Never
+  # Explicitly set revisionHistoryLimit to preserve previous behavior.
+  # In cert-manager 1.18+, the default changed from unlimited to 1.
+  revisionHistoryLimit: 1


### PR DESCRIPTION
- Makefile support set OCP version
- enable seccompProfile on new OCP version
- update: since we are pulling of "latest" from cert-manager: explicilty set Never (new default is Always since 1.18+)